### PR TITLE
Allow name for the image to be optional

### DIFF
--- a/Docker.fs
+++ b/Docker.fs
@@ -3,16 +3,14 @@ module Fake.DockerHelper
 open Fake
 
 type DockerImageName =
-  { Host : string option
+  { Registry : string option
     Repository : string
-    Name : string option
     Tag : string option
   }
   override x.ToString () =
-    let h = defaultArg (x.Host |> Option.map (fun h -> h + "/")) ""
+    let r = defaultArg (x.Registry |> Option.map (fun r -> r + "/")) ""
     let t = defaultArg (x.Tag |> Option.map (fun t -> ":" + t)) ""
-    let n = defaultArg (x.Name |> Option.map (fun n -> "/" + n)) ""
-    sprintf "%s%s%s%s" h x.Repository n t
+    sprintf "%s%s%s" r x.Repository t
 
 type DockerInstance = DockerInstance of string
 

--- a/Docker.fs
+++ b/Docker.fs
@@ -5,13 +5,14 @@ open Fake
 type DockerImageName =
   { Host : string option
     Repository : string
-    Name : string
+    Name : string option
     Tag : string option
   }
   override x.ToString () =
     let h = defaultArg (x.Host |> Option.map (fun h -> h + "/")) ""
     let t = defaultArg (x.Tag |> Option.map (fun t -> ":" + t)) ""
-    sprintf "%s%s/%s%s" h x.Repository x.Name t
+    let n = defaultArg (x.Name |> Option.map (fun n -> "/" + n)) ""
+    sprintf "%s%s%s%s" h x.Repository n t
 
 type DockerInstance = DockerInstance of string
 


### PR DESCRIPTION
It appears that Amazon ECR does not support "/" in the repository name, it is sometimes handy to exclude the name and use only repository as the destination.