### PR TITLE
More docker helpers

### DIFF
--- a/Docker.fs
+++ b/Docker.fs
@@ -115,6 +115,13 @@ let dockerGetHostPort (exposedPort : uint16) inst =
   |> readFirstLine
   |> System.UInt16.Parse
 
+let dockerGetIpAddress inst =
+  let path = "'{{.NetworkSettings.IPAddress}}'"
+  (inst, path)
+  |> Inspect
+  |> dockerAsk
+  |> readFirstLine
+
 let dockerTagPushRm image tag =
   dockerDo (Tag (image, tag))
   try

--- a/Docker.fs
+++ b/Docker.fs
@@ -122,6 +122,21 @@ let dockerGetIpAddress inst =
   |> dockerAsk
   |> readFirstLine
 
+let getVersion() =
+  "--version"
+  |> CustomExec
+  |> dockerAsk
+  |> fun x -> x.Messages
+  |> separated ""
+
+let isInstalled() =
+  try
+      let result = "--version"
+                    |> CustomExec
+                    |> dockerAsk
+      result.OK
+  with _ -> false
+
 let dockerTagPushRm image tag =
   dockerDo (Tag (image, tag))
   try


### PR DESCRIPTION
1. Added `dockerGetIpAddress` (similar to `dockerGetHostPort`)
2. Added `DockerHelper.getVersion()` (similar to [this](https://github.com/fsharp/FAKE/blob/master/src/app/FakeLib/DotNetCLIHelper.fs#L14-14))
3. Added `DockerHelper.isInstalled()` (again, similar to [this](https://github.com/fsharp/FAKE/blob/master/src/app/FakeLib/DotNetCLIHelper.fs#L24))